### PR TITLE
Fix chemins relatifs SCSS & amélioration du .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,17 @@
+# Packages
 /vendor
 /node_modules
-/config
+
+# Configuration personnelle
+/config/config.yaml
+
+# IDE
+.vscode/
+.idea/
 .codiumai
 /docs.qodo
 /.qodo/
-.idea/
+
+# Fichiers lock
+package-lock.json
+composer.lock

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -1,6 +1,6 @@
-@import "./node_modules/bootstrap/scss/functions";
-@import "./node_modules/bootstrap/scss/variables";
-@import "./node_modules/bootstrap/scss/mixins";
+@import "../node_modules/bootstrap/scss/functions";
+@import "../node_modules/bootstrap/scss/variables";
+@import "../node_modules/bootstrap/scss/mixins";
 
 // Custom colors
 $custom-colors: (
@@ -24,7 +24,7 @@ $theme-colors: map-merge(
 // Add additional custom colors to the theme
 $theme-colors: map-merge($theme-colors, $custom-colors);
 
-@import "./node_modules/bootstrap/scss/bootstrap";
+@import "../node_modules/bootstrap/scss/bootstrap";
 
 // pour compiler scss en css -> dans terminal :
 // sass scss/main.scss scss/output/bootstrap.css


### PR DESCRIPTION
Correction des chemins relatifs SCSS pour éviter les erreurs d'importation.
Nettoyage et amélioration du .gitignore : 
- Ajout des fichiers et dossiers spécifiques aux IDEs (.vscode/, .idea/, etc.).
- Ajout des fichiers lock (package-lock.json, composer.lock).